### PR TITLE
Update meta.yaml

### DIFF
--- a/conda_recipe/meta.yaml
+++ b/conda_recipe/meta.yaml
@@ -23,7 +23,7 @@ requirements:
     - python {{ python }}
     - numpy
     - openbabel >=3
-    - ipywidgets >=7.5
+    - ipywidgets >=7.5, <8
     - nglview >=2.7
     - pyyaml
 


### PR DESCRIPTION
The current conda recipe defaults to ipywidgets 8 which breaks the dependency on uploader.keys(). Here I've changed it to keep 7.